### PR TITLE
Fix a wrong path to a bash completion file

### DIFF
--- a/dev-lang/ldc2/ldc2-0.16.1.ebuild
+++ b/dev-lang/ldc2/ldc2-0.16.1.ebuild
@@ -41,5 +41,5 @@ src_install() {
 	cmake-utils_src_install
 
 	rm -rf "${ED}"/usr/share/bash-completion
-	newbashcomp "bash_completion.d/ldc" ${PN}
+	newbashcomp "bash_completion.d/ldc2" ${PN}
 }


### PR DESCRIPTION
The ebuild compiles successfully, but it has failed during install phase.
I got the following output after the installation failure.

```
...
>>> Source compiled.
>>> Test phase [not enabled]: dev-lang/ldc2-0.16.1

>>> Install ldc2-0.16.1 into /tmp/portage/dev-lang/ldc2-0.16.1/image/ category dev-lang
>>> Working in BUILD_DIR: "/tmp/portage/dev-lang/ldc2-0.16.1/work/ldc2-0.16.1_build"
make -j8 install
[  0%] Built target idgen
[  0%] Built target gen_gccbuiltins
[  1%] Built target ldmd2
[  3%] Built target impcnvgen
[ 18%] Built target LDCShared
[ 18%] Built target ldc2
[ 35%] Built target phobos2-ldc
[ 59%] Built target druntime-ldc
[ 83%] Built target druntime-ldc-debug
[100%] Built target phobos2-ldc-debug
Install the project...
-- Install configuration: "Gentoo"
-- Installing: /tmp/portage/dev-lang/ldc2-0.16.1/image/usr/bin/ldc2
...
-- Installing: /tmp/portage/dev-lang/ldc2-0.16.1/image/usr/lib64/libphobos2-ldc-debug.a
 * ERROR: dev-lang/ldc2-0.16.1::ldc failed (install phase):
 *   !!! newins: bash_completion.d/ldc does not exist
```
